### PR TITLE
Add jsonapi examples and examples like swagger

### DIFF
--- a/src/n8n/SchemaToINodeProperties.ts
+++ b/src/n8n/SchemaToINodeProperties.ts
@@ -102,7 +102,7 @@ export class N8NINodeProperties {
         }
         const fieldParameterKeys: Partial<INodeProperties> = {
             displayName: lodash.startCase(parameter.name),
-            name: parameter.name.replace(/\./g, "-"),
+            name: encodeURIComponent(parameter.name.replace(/\./g, "-")),
             required: parameter.required,
             description: parameter.description,
             default: parameter.example,

--- a/src/n8n/SchemaToINodeProperties.ts
+++ b/src/n8n/SchemaToINodeProperties.ts
@@ -39,9 +39,9 @@ export class N8NINodeProperties {
     }
 
     fromSchema(schema: Schema): FromSchemaNodeProperty {
-        schema = this.refResolver.resolve<OpenAPIV3.SchemaObject>(schema)
+        schema = this.refResolver.resolve<OpenAPIV3.SchemaObject>(schema);
         let type: NodePropertyTypes;
-        let defaultValue = this.schemaExample.extractExample(schema)
+        let defaultValue = this.schemaExample.extractExample(schema);
 
         let options = undefined
 
@@ -65,7 +65,7 @@ export class N8NINodeProperties {
                 break;
             case 'array':
                 let schemaAsArray = schema as any;
-                if (schemaAsArray.items && schemaAsArray.items.enum.length > 0) {
+                if (schemaAsArray.items && schemaAsArray.items.enum && schemaAsArray.items.enum.length > 0) {
                     type = 'multiOptions';
                     options = schemaAsArray.items.enum.map((value: string) => {
                         return {

--- a/src/n8n/SchemaToINodeProperties.ts
+++ b/src/n8n/SchemaToINodeProperties.ts
@@ -43,6 +43,12 @@ export class N8NINodeProperties {
         let type: NodePropertyTypes;
         let defaultValue = this.schemaExample.extractExample(schema)
 
+        let options = undefined
+
+        if (schema.allOf) {
+            schema.type = 'object';
+        }
+
         switch (schema.type) {
             case 'boolean':
                 type = 'boolean';

--- a/src/openapi/RefResolver.ts
+++ b/src/openapi/RefResolver.ts
@@ -11,20 +11,6 @@ export class RefResolver {
      */
     resolveRef<T>(schema: OpenAPIV3.ReferenceObject | T): [T, string[]?] {
         // @ts-ignore
-        if ("properties" in schema) {
-            return [schema as T, undefined];
-        }
-        // @ts-ignore
-        if ("oneOf" in schema) {
-            // @ts-ignore
-            schema = schema.oneOf[0];
-        }
-        // @ts-ignore
-        if ("anyOf" in schema) {
-            // @ts-ignore
-            schema = schema.anyOf[0];
-        }
-        // @ts-ignore
         if ('$ref' in schema) {
             const schemaResolved = this.findRef(schema['$ref']);
             // Remove $ref from schema, add all other properties

--- a/src/openapi/RefResolver.ts
+++ b/src/openapi/RefResolver.ts
@@ -26,16 +26,6 @@ export class RefResolver {
             schema = schema.anyOf[0]
         }
         // @ts-ignore
-        if ("allOf" in schema) {
-            // @ts-ignore
-            const results = schema.allOf.map((s) => this.resolveRef(s));
-            const schemas = results.map((r: any) => r[0]);
-            const refs = results.map((r: any) => r[1]);
-            const refsFlat = lodash.flatten<string>(refs);
-            const object = Object.assign({}, ...schemas);
-            return [object as T, refsFlat]
-        }
-        // @ts-ignore
         if ('$ref' in schema) {
             const schemaResolved = this.findRef(schema['$ref']);
             // Remove $ref from schema, add all other properties

--- a/src/openapi/RefResolver.ts
+++ b/src/openapi/RefResolver.ts
@@ -1,5 +1,4 @@
 import {OpenAPIV3} from "openapi-types";
-import * as lodash from "lodash";
 
 export class RefResolver {
     constructor(private doc: any) {
@@ -13,17 +12,17 @@ export class RefResolver {
     resolveRef<T>(schema: OpenAPIV3.ReferenceObject | T): [T, string[]?] {
         // @ts-ignore
         if ("properties" in schema) {
-            return [schema as T, undefined]
+            return [schema as T, undefined];
         }
         // @ts-ignore
         if ("oneOf" in schema) {
             // @ts-ignore
-            schema = schema.oneOf[0]
+            schema = schema.oneOf[0];
         }
         // @ts-ignore
         if ("anyOf" in schema) {
             // @ts-ignore
-            schema = schema.anyOf[0]
+            schema = schema.anyOf[0];
         }
         // @ts-ignore
         if ('$ref' in schema) {
@@ -31,13 +30,13 @@ export class RefResolver {
             // Remove $ref from schema, add all other properties
             const {$ref, ...rest} = schema;
             Object.assign(rest, schemaResolved);
-            return [rest as T, [$ref]]
+            return [rest as T, [$ref]];
         }
-        return [schema as T, undefined]
+        return [schema as T, undefined];
     }
 
     resolve<T>(schema: OpenAPIV3.ReferenceObject | T): T {
-        return this.resolveRef(schema)[0]
+        return this.resolveRef(schema)[0];
     }
 
     private findRef(ref: string): OpenAPIV3.SchemaObject {

--- a/src/openapi/SchemaExample.ts
+++ b/src/openapi/SchemaExample.ts
@@ -69,10 +69,7 @@ class SchemaExampleBuilder {
                     return []
                 case 'number':
                 case 'integer':
-                    if (schema.maximum || schema.minimum || schema.exclusiveMinimum || schema.exclusiveMaximum || schema.multipleOf) {
-                        return generateNumberWithConstraints(schema);
-                    }
-                    return 0;
+                    return generateNumberWithConstraints(schema);
                 default: // null for OpenAPI 3.1
                     return null;
             }

--- a/src/openapi/SchemaExample.ts
+++ b/src/openapi/SchemaExample.ts
@@ -4,7 +4,9 @@ import {OpenAPIV3} from "openapi-types";
 class SchemaExampleBuilder {
     private visitedRefs: Set<string> = new Set<string>();
 
-    constructor(private resolver: RefResolver) {
+    constructor(private resolver: RefResolver, refs?: Set<string>) {
+        if (refs)
+            this.visitedRefs = new Set([...refs])
     }
 
     build(schema: OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject, guessDefault: boolean = false): any {
@@ -43,7 +45,7 @@ class SchemaExampleBuilder {
         if (schema.properties) {
             const obj: any = example ?? {};
             for (const key in schema.properties) {
-               obj[key] = this.build(schema.properties[key], true);
+                obj[key] = (new SchemaExampleBuilder(this.resolver, this.visitedRefs)).build(schema.properties[key], true);
             }
             example = obj;
         }

--- a/src/openapi/SchemaExample.ts
+++ b/src/openapi/SchemaExample.ts
@@ -7,29 +7,29 @@ class SchemaExampleBuilder {
     constructor(private resolver: RefResolver) {
     }
 
-    build(schema: OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject): any {
-        let refs: string[] | undefined
-        [schema, refs] = this.resolver.resolveRef(schema)
+    build(schema: OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject, guessDefault: boolean = false): any {
+        let refs: string[] | undefined;
+        [schema, refs] = this.resolver.resolveRef(schema);
 
-        let example: any = undefined
+        let example: any = undefined;
 
         if (refs) {
             // Prevent infinite recursion
             for (const ref of refs) {
                 if (this.visitedRefs.has(ref)) {
-                    return {}
+                    return {};
                 }
                 this.visitedRefs.add(ref);
             }
         }
         if ('oneOf' in schema) {
-            return this.build(schema.oneOf!![0]);
+            return this.build(schema.oneOf!![0], guessDefault);
         }
         if (schema.example !== undefined) {
             return schema.example;
         }
         if ('allOf' in schema) {
-            const examples = schema.allOf!!.map((s) => this.build(s));
+            const examples = schema.allOf!!.map((s) => this.build(s, true));
             example = Object.assign({}, ...examples);
         }
 
@@ -39,7 +39,7 @@ class SchemaExampleBuilder {
         if (schema.properties) {
             const obj: any = example ?? {};
             for (const key in schema.properties) {
-                obj[key] = this.build(schema.properties[key]);
+                obj[key] = this.build(schema.properties[key], true);
             }
             example = obj;
         }
@@ -47,25 +47,31 @@ class SchemaExampleBuilder {
             return schema.enum[0];
         }
         if ('items' in schema && schema.items) {
-            return [this.build(schema.items)];
+            if (schema.type === 'array' && schema.items && (schema.items as OpenAPIV3.SchemaObject).enum) {
+                return (schema.items as OpenAPIV3.SchemaObject).enum;
+            }
+            return [this.build(schema.items, true) ?? "string"];
         }
         if (example) {
             return example;
         }
         // In 3.1 schema.type can be an array
         let type = (schema.type && typeof schema.type !== "string") ? schema.type[0] : schema.type;
-        if (type) {
+        if (type && guessDefault) {
             switch (type) {
                 case 'boolean':
                     return true;
                 case 'string':
-                    return '';
+                    return generateString(schema);
                 case 'object':
                     return {};
                 case 'array':
-                    return [];
+                    return []
                 case 'number':
                 case 'integer':
+                    if (schema.maximum || schema.minimum || schema.exclusiveMinimum || schema.exclusiveMaximum || schema.multipleOf) {
+                        return generateNumberWithConstraints(schema);
+                    }
                     return 0;
                 default: // null for OpenAPI 3.1
                     return null;
@@ -73,6 +79,65 @@ class SchemaExampleBuilder {
         }
         return undefined;
     }
+}
+
+const generateString = (schema: OpenAPIV3.SchemaObject) => {
+    const {format} = schema;
+
+    switch (format) {
+        case 'uuid':
+            return "3fa85f64-5717-4562-b3fc-2c963f66afa6";
+    }
+    return "string";
+}
+
+
+function generateNumberWithConstraints(schema: OpenAPIV3.SchemaObject) {
+    const {minimum, maximum, exclusiveMinimum, exclusiveMaximum} = schema;
+    const {multipleOf} = schema;
+    let defaultNumber = 0;
+    switch (schema.format) {
+        case 'int32':
+            defaultNumber = (2 ** 30) >>> 0;
+            break;
+        case 'int64':
+            defaultNumber = 2 ** 53 - 1;
+            break;
+        case 'float':
+        case 'double':
+            defaultNumber = 0.1;
+            break;
+    }
+
+    const epsilon = Number.isInteger(defaultNumber) ? 1 : Number.EPSILON;
+    let minValue = typeof minimum === "number" ? minimum : null;
+    let maxValue = typeof maximum === "number" ? maximum : null;
+    let constrainedNumber = defaultNumber;
+
+    if (typeof exclusiveMinimum === "number") {
+        minValue =
+            minValue !== null
+                ? Math.max(minValue, exclusiveMinimum + epsilon)
+                : exclusiveMinimum + epsilon;
+    }
+    if (typeof exclusiveMaximum === "number") {
+        maxValue =
+            maxValue !== null
+                ? Math.min(maxValue, exclusiveMaximum - epsilon)
+                : exclusiveMaximum - epsilon;
+    }
+    constrainedNumber =
+        (minValue as any > (maxValue as any) && defaultNumber) || minValue || maxValue || constrainedNumber;
+
+    if (typeof multipleOf === "number" && multipleOf > 0) {
+        const remainder = constrainedNumber % multipleOf;
+        constrainedNumber =
+            remainder === 0
+                ? constrainedNumber
+                : constrainedNumber + multipleOf - remainder;
+    }
+
+    return constrainedNumber;
 }
 
 export class SchemaExample {

--- a/src/openapi/SchemaExample.ts
+++ b/src/openapi/SchemaExample.ts
@@ -22,39 +22,47 @@ class SchemaExampleBuilder {
                 this.visitedRefs.add(ref);
             }
         }
-        if ('oneOf' in schema) {
-            return this.build(schema.oneOf!![0], guessDefault);
-        }
+
         if (schema.example !== undefined) {
             return schema.example;
-        }
-        if ('allOf' in schema) {
-            const examples = schema.allOf!!.map((s) => this.build(s, true));
-            example = Object.assign({}, ...examples);
         }
 
         if (schema.default !== undefined) {
             return schema.default;
         }
+
+        if ('oneOf' in schema) {
+            return this.build(schema.oneOf!![0], guessDefault);
+        }
+
+        if ('allOf' in schema) {
+            const examples = schema.allOf!!.map((s) => this.build(s, true));
+            example = Object.assign({}, ...examples);
+        }
+
         if (schema.properties) {
             const obj: any = example ?? {};
             for (const key in schema.properties) {
-                obj[key] = this.build(schema.properties[key], true);
+               obj[key] = this.build(schema.properties[key], true);
             }
             example = obj;
         }
+
+        if (example) {
+            return example;
+        }
+
         if (schema.enum) {
             return schema.enum[0];
         }
+
         if ('items' in schema && schema.items) {
             if (schema.type === 'array' && schema.items && (schema.items as OpenAPIV3.SchemaObject).enum) {
                 return (schema.items as OpenAPIV3.SchemaObject).enum;
             }
             return [this.build(schema.items, true) ?? "string"];
         }
-        if (example) {
-            return example;
-        }
+
         // In 3.1 schema.type can be an array
         let type = (schema.type && typeof schema.type !== "string") ? schema.type[0] : schema.type;
         if (type && guessDefault) {

--- a/tests/jsonapi-openapi.spec.ts
+++ b/tests/jsonapi-openapi.spec.ts
@@ -1,0 +1,201 @@
+import {N8NPropertiesBuilder} from "../src/N8NPropertiesBuilder";
+import {INodeProperties} from "n8n-workflow";
+
+test('petstore.json', () => {
+    const doc = require('./samples/jsonapi-openapi.json');
+    const config = {}
+    const parser = new N8NPropertiesBuilder(doc, config);
+    const result = parser.build()
+
+    const expected: INodeProperties[] =  [
+        {
+            "displayName": "Resource",
+            "name": "resource",
+            "type": "options",
+            "noDataExpression": true,
+            "options": [
+                {
+                    "name": "Model",
+                    "value": "Model",
+                    "description": "Endpoints for the `Model` resource."
+                }
+            ],
+            "default": ""
+        },
+        {
+            "displayName": "Operation",
+            "name": "operation",
+            "type": "options",
+            "noDataExpression": true,
+            "displayOptions": {
+                "show": {
+                    "resource": [
+                        "Model"
+                    ]
+                }
+            },
+            "options": [
+                {
+                    "name": "Create Model",
+                    "value": "Create Model",
+                    "action": "Create a new model",
+                    "description": "Creates a new model resource with the provided data.",
+                    "routing": {
+                        "request": {
+                            "method": "POST",
+                            "url": "=/model/"
+                        }
+                    }
+                }
+            ],
+            "default": ""
+        },
+        {
+            "displayName": "POST /model/",
+            "name": "operation",
+            "type": "notice",
+            "typeOptions": {
+                "theme": "info"
+            },
+            "default": "",
+            "displayOptions": {
+                "show": {
+                    "resource": [
+                        "Model"
+                    ],
+                    "operation": [
+                        "Create Model"
+                    ]
+                }
+            }
+        },
+        {
+            "displayName": "Fields Model",
+            "name": "fields%5Bmodel%5D",
+            "description": "Specifies which fields should be returned.",
+            "default": [
+                "componentType", "count",
+                    "array",
+                    "modelType",
+                    "subModel",
+                    "view",
+                    "name"
+            ],
+            "type": "multiOptions",
+            "options": [
+                {
+                    "name": "Component Type",
+                    "value": "componentType"
+                },
+                {
+                    "name": "Count",
+                    "value": "count"
+                },
+                {
+                    "name": "Array",
+                    "value": "array"
+                },
+                {
+                    "name": "Model Type",
+                    "value": "modelType"
+                },
+                {
+                    "name": "Sub Model",
+                    "value": "subModel"
+                },
+                {
+                    "name": "View",
+                    "value": "view"
+                },
+                {
+                    "name": "Name",
+                    "value": "name"
+                }
+            ],
+            "routing": {
+                "send": {
+                    "type": "query",
+                    "property": "fields[model]",
+                    "value": "={{ $value.join(',') }}",
+                    "propertyInDotNotation": false
+                }
+            },
+            "displayOptions": {
+                "show": {
+                    "resource": [
+                        "Model"
+                    ],
+                    "operation": [
+                        "Create Model"
+                    ]
+                }
+            }
+        },
+        {
+            "displayName": "Include",
+            "name": "include",
+            "description": "Specifies which related resources should be returned.",
+            "default": [
+                "view", "subModel"
+            ],
+            "type": "multiOptions",
+            "options": [
+                {
+                    "name": "View",
+                    "value": "view"
+                },
+                {
+                    "name": "Sub Model",
+                    "value": "subModel"
+                }
+            ],
+            "routing": {
+                "send": {
+                    "type": "query",
+                    "property": "include",
+                    "value": "={{ $value.join(',') }}",
+                    "propertyInDotNotation": false
+                }
+            },
+            "displayOptions": {
+                "show": {
+                    "resource": [
+                        "Model"
+                    ],
+                    "operation": [
+                        "Create Model"
+                    ]
+                }
+            }
+        },
+        {
+            "required": true,
+            "displayName": "Data",
+            "description": undefined,
+            "name": "data",
+            "options": undefined,
+            "type": "json",
+            "default": "{\n  \"type\": \"model\",\n  \"attributes\": {\n    \"byteOffset\": 0,\n    \"componentType\": 0,\n    \"count\": 1073741824,\n    \"type\": \"TYPE_A\",\n    \"array\": [\n      \"string\"\n    ],\n    \"name\": \"string\"\n  },\n  \"relationships\": {\n    \"view\": null,\n    \"subModel\": null\n  }\n}",
+            "routing": {
+                "send": {
+                    "property": "data",
+                    "propertyInDotNotation": false,
+                    "type": "body",
+                    "value": "={{ JSON.parse($value) }}"
+                }
+            },
+            "displayOptions": {
+                "show": {
+                    "resource": [
+                        "Model"
+                    ],
+                    "operation": [
+                        "Create Model"
+                    ]
+                }
+            }
+        }
+    ]
+
+    expect(result).toEqual(expected);
+})

--- a/tests/petstore.spec.ts
+++ b/tests/petstore.spec.ts
@@ -329,6 +329,7 @@ test('petstore.json', () => {
         },
         {
             "default": 10,
+            "description": undefined,
             "displayName": "Id",
             "displayOptions": {
                 "show": {
@@ -341,6 +342,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "id",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "id",
@@ -353,6 +355,7 @@ test('petstore.json', () => {
         },
         {
             "default": "doggie",
+            "description": undefined,
             "displayName": "Name",
             "displayOptions": {
                 "show": {
@@ -365,6 +368,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "name",
+            "options": undefined,
             "required": true,
             "routing": {
                 "send": {
@@ -378,6 +382,7 @@ test('petstore.json', () => {
         },
         {
             "default": "{\n  \"id\": 1,\n  \"name\": \"Dogs\"\n}",
+            "description": undefined,
             "displayName": "Category",
             "displayOptions": {
                 "show": {
@@ -390,6 +395,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "category",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "category",
@@ -401,7 +407,8 @@ test('petstore.json', () => {
             "type": "json"
         },
         {
-            "default": "[\n  null\n]",
+            "default": "[\n  \"string\"\n]",
+            "description": undefined,
             "displayName": "Photo Urls",
             "displayOptions": {
                 "show": {
@@ -414,6 +421,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "photoUrls",
+            "options": undefined,
             "required": true,
             "routing": {
                 "send": {
@@ -426,7 +434,8 @@ test('petstore.json', () => {
             "type": "json"
         },
         {
-            "default": "[\n  {}\n]",
+            "default": "[\n  {\n    \"id\": 0,\n    \"name\": \"string\"\n  }\n]",
+            "description": undefined,
             "displayName": "Tags",
             "displayOptions": {
                 "show": {
@@ -439,6 +448,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "tags",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "tags",
@@ -509,6 +519,7 @@ test('petstore.json', () => {
         },
         {
             "default": 10,
+            "description": undefined,
             "displayName": "Id",
             "displayOptions": {
                 "show": {
@@ -521,6 +532,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "id",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "id",
@@ -533,6 +545,7 @@ test('petstore.json', () => {
         },
         {
             "default": "doggie",
+            "description": undefined,
             "displayName": "Name",
             "displayOptions": {
                 "show": {
@@ -545,6 +558,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "name",
+            "options": undefined,
             "required": true,
             "routing": {
                 "send": {
@@ -558,6 +572,7 @@ test('petstore.json', () => {
         },
         {
             "default": "{\n  \"id\": 1,\n  \"name\": \"Dogs\"\n}",
+            "description": undefined,
             "displayName": "Category",
             "displayOptions": {
                 "show": {
@@ -570,6 +585,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "category",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "category",
@@ -581,7 +597,8 @@ test('petstore.json', () => {
             "type": "json"
         },
         {
-            "default": "[\n  null\n]",
+            "default": "[\n  \"string\"\n]",
+            "description": undefined,
             "displayName": "Photo Urls",
             "displayOptions": {
                 "show": {
@@ -594,6 +611,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "photoUrls",
+            "options": undefined,
             "required": true,
             "routing": {
                 "send": {
@@ -606,7 +624,8 @@ test('petstore.json', () => {
             "type": "json"
         },
         {
-            "default": "[\n  {}\n]",
+            "default": "[\n  {\n    \"id\": 0,\n    \"name\": \"string\"\n  }\n]",
+            "description": undefined,
             "displayName": "Tags",
             "displayOptions": {
                 "show": {
@@ -619,6 +638,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "tags",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "tags",
@@ -746,7 +766,7 @@ test('petstore.json', () => {
             }
         },
         {
-            "default": "[\n  null\n]",
+            "default": "[\n  \"string\"\n]",
             "description": "Tags to filter by",
             "displayName": "Tags",
             "displayOptions": {
@@ -760,6 +780,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "tags",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "tags",
@@ -804,6 +825,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "petId",
+            "options": undefined,
             "required": true,
             "type": "number"
         },
@@ -841,6 +863,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "petId",
+            "options": undefined,
             "required": true,
             "type": "number"
         },
@@ -859,6 +882,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "name",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "name",
@@ -884,6 +908,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "status",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "status",
@@ -928,6 +953,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "api_key",
+            "options": undefined,
             "routing": {
                 "request": {
                     "headers": {
@@ -952,6 +978,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "petId",
+            "options": undefined,
             "required": true,
             "type": "number"
         },
@@ -989,6 +1016,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "petId",
+            "options": undefined,
             "required": true,
             "type": "number"
         },
@@ -1007,6 +1035,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "additionalMetadata",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "additionalMetadata",
@@ -1073,6 +1102,7 @@ test('petstore.json', () => {
         },
         {
             "default": 10,
+            "description": undefined,
             "displayName": "Id",
             "displayOptions": {
                 "show": {
@@ -1085,6 +1115,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "id",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "id",
@@ -1097,6 +1128,7 @@ test('petstore.json', () => {
         },
         {
             "default": 198772,
+            "description": undefined,
             "displayName": "Pet Id",
             "displayOptions": {
                 "show": {
@@ -1109,6 +1141,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "petId",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "petId",
@@ -1121,6 +1154,7 @@ test('petstore.json', () => {
         },
         {
             "default": 7,
+            "description": undefined,
             "displayName": "Quantity",
             "displayOptions": {
                 "show": {
@@ -1133,6 +1167,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "quantity",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "quantity",
@@ -1145,6 +1180,7 @@ test('petstore.json', () => {
         },
         {
             "default": "",
+            "description": undefined,
             "displayName": "Ship Date",
             "displayOptions": {
                 "show": {
@@ -1157,6 +1193,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "shipDate",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "shipDate",
@@ -1208,6 +1245,7 @@ test('petstore.json', () => {
         },
         {
             "default": true,
+            "description": undefined,
             "displayName": "Complete",
             "displayOptions": {
                 "show": {
@@ -1220,6 +1258,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "complete",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "complete",
@@ -1264,6 +1303,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "orderId",
+            "options": undefined,
             "required": true,
             "type": "number"
         },
@@ -1301,6 +1341,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "orderId",
+            "options": undefined,
             "required": true,
             "type": "number"
         },
@@ -1325,6 +1366,7 @@ test('petstore.json', () => {
         },
         {
             "default": 10,
+            "description": undefined,
             "displayName": "Id",
             "displayOptions": {
                 "show": {
@@ -1337,6 +1379,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "id",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "id",
@@ -1349,6 +1392,7 @@ test('petstore.json', () => {
         },
         {
             "default": "theUser",
+            "description": undefined,
             "displayName": "Username",
             "displayOptions": {
                 "show": {
@@ -1361,6 +1405,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "username",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "username",
@@ -1373,6 +1418,7 @@ test('petstore.json', () => {
         },
         {
             "default": "John",
+            "description": undefined,
             "displayName": "First Name",
             "displayOptions": {
                 "show": {
@@ -1385,6 +1431,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "firstName",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "firstName",
@@ -1397,6 +1444,7 @@ test('petstore.json', () => {
         },
         {
             "default": "James",
+            "description": undefined,
             "displayName": "Last Name",
             "displayOptions": {
                 "show": {
@@ -1409,6 +1457,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "lastName",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "lastName",
@@ -1421,6 +1470,7 @@ test('petstore.json', () => {
         },
         {
             "default": "john@email.com",
+            "description": undefined,
             "displayName": "Email",
             "displayOptions": {
                 "show": {
@@ -1433,6 +1483,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "email",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "email",
@@ -1445,6 +1496,7 @@ test('petstore.json', () => {
         },
         {
             "default": "12345",
+            "description": undefined,
             "displayName": "Password",
             "displayOptions": {
                 "show": {
@@ -1457,6 +1509,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "password",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "password",
@@ -1469,6 +1522,7 @@ test('petstore.json', () => {
         },
         {
             "default": "12345",
+            "description": undefined,
             "displayName": "Phone",
             "displayOptions": {
                 "show": {
@@ -1481,6 +1535,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "phone",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "phone",
@@ -1506,6 +1561,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "userStatus",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "userStatus",
@@ -1537,6 +1593,7 @@ test('petstore.json', () => {
         },
         {
             "default": "{\n  \"id\": 10,\n  \"username\": \"theUser\",\n  \"firstName\": \"John\",\n  \"lastName\": \"James\",\n  \"email\": \"john@email.com\",\n  \"password\": \"12345\",\n  \"phone\": \"12345\",\n  \"userStatus\": 1\n}",
+            "description": undefined,
             "displayName": "Body",
             "displayOptions": {
                 "show": {
@@ -1549,6 +1606,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "body",
+            "options": undefined,
             "routing": {
                 "request": {
                     "body": "={{ JSON.parse($value) }}"
@@ -1590,6 +1648,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "username",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "username",
@@ -1615,6 +1674,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "password",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "password",
@@ -1678,6 +1738,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "username",
+            "options": undefined,
             "required": true,
             "type": "string"
         },
@@ -1715,11 +1776,13 @@ test('petstore.json', () => {
                 }
             },
             "name": "username",
+            "options": undefined,
             "required": true,
             "type": "string"
         },
         {
             "default": 10,
+            "description": undefined,
             "displayName": "Id",
             "displayOptions": {
                 "show": {
@@ -1732,6 +1795,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "id",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "id",
@@ -1744,6 +1808,7 @@ test('petstore.json', () => {
         },
         {
             "default": "theUser",
+            "description": undefined,
             "displayName": "Username",
             "displayOptions": {
                 "show": {
@@ -1756,6 +1821,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "username",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "username",
@@ -1768,6 +1834,7 @@ test('petstore.json', () => {
         },
         {
             "default": "John",
+            "description": undefined,
             "displayName": "First Name",
             "displayOptions": {
                 "show": {
@@ -1780,6 +1847,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "firstName",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "firstName",
@@ -1792,6 +1860,7 @@ test('petstore.json', () => {
         },
         {
             "default": "James",
+            "description": undefined,
             "displayName": "Last Name",
             "displayOptions": {
                 "show": {
@@ -1804,6 +1873,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "lastName",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "lastName",
@@ -1816,6 +1886,7 @@ test('petstore.json', () => {
         },
         {
             "default": "john@email.com",
+            "description": undefined,
             "displayName": "Email",
             "displayOptions": {
                 "show": {
@@ -1828,6 +1899,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "email",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "email",
@@ -1840,6 +1912,7 @@ test('petstore.json', () => {
         },
         {
             "default": "12345",
+            "description": undefined,
             "displayName": "Password",
             "displayOptions": {
                 "show": {
@@ -1852,6 +1925,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "password",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "password",
@@ -1864,6 +1938,7 @@ test('petstore.json', () => {
         },
         {
             "default": "12345",
+            "description": undefined,
             "displayName": "Phone",
             "displayOptions": {
                 "show": {
@@ -1876,6 +1951,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "phone",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "phone",
@@ -1901,6 +1977,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "userStatus",
+            "options": undefined,
             "routing": {
                 "send": {
                     "property": "userStatus",
@@ -1945,6 +2022,7 @@ test('petstore.json', () => {
                 }
             },
             "name": "username",
+            "options": undefined,
             "required": true,
             "type": "string"
         }

--- a/tests/petstore.spec.ts
+++ b/tests/petstore.spec.ts
@@ -434,7 +434,7 @@ test('petstore.json', () => {
             "type": "json"
         },
         {
-            "default": "[\n  {\n    \"id\": 0,\n    \"name\": \"string\"\n  }\n]",
+            "default": "[\n  {\n    \"id\": 9007199254740991,\n    \"name\": \"string\"\n  }\n]",
             "description": undefined,
             "displayName": "Tags",
             "displayOptions": {
@@ -624,7 +624,7 @@ test('petstore.json', () => {
             "type": "json"
         },
         {
-            "default": "[\n  {\n    \"id\": 0,\n    \"name\": \"string\"\n  }\n]",
+            "default": "[\n  {\n    \"id\": 9007199254740991,\n    \"name\": \"string\"\n  }\n]",
             "description": undefined,
             "displayName": "Tags",
             "displayOptions": {

--- a/tests/samples/jsonapi-openapi.json
+++ b/tests/samples/jsonapi-openapi.json
@@ -1,0 +1,734 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Example of a JSON API in a OpenAPI format",
+    "description": "My json api example",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/model/": {
+      "post": {
+        "tags": [
+          "Model"
+        ],
+        "summary": "Create a new model",
+        "description": "Creates a new model resource with the provided data.",
+        "operationId": "create_model",
+        "parameters": [
+          {
+            "name": "fields[model]",
+            "in": "query",
+            "description": "Specifies which fields should be returned.",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "componentType",
+                  "count",
+                  "array",
+                  "modelType",
+                  "subModel",
+                  "view",
+                  "name"
+                ]
+              }
+            },
+            "explode": false
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "description": "Specifies which related resources should be returned.",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "view",
+                  "subModel"
+                ]
+              }
+            },
+            "explode": false
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ModelResourceCreationRequestBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Success response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data",
+                    "included",
+                    "links"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/ModelResourceObject"
+                      }
+                    },
+                    "included": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/ModelResourceRelationshipValue"
+                      }
+                    },
+                    "links": {
+                      "type": "object",
+                      "required": [
+                        "self"
+                      ],
+                      "properties": {
+                        "self": {
+                          "type": "string",
+                          "default": "/model"
+                        },
+                        "first": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "default": "/model?page[number]=1&page[size]=10"
+                        },
+                        "last": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "default": "/model?page[number]=10&page[size]=10"
+                        },
+                        "prev": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "default": "/model?page[number]=2&page[size]=10"
+                        },
+                        "next": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "default": "/model?page[number]=4&page[size]=10"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "required": [
+                        "errors"
+                      ],
+                      "properties": {
+                        "errors": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "status",
+                              "title",
+                              "detail"
+                            ],
+                            "properties": {
+                              "status": {
+                                "type": "string",
+                                "example": "404"
+                              },
+                              "title": {
+                                "type": "string",
+                                "example": "Not found"
+                              },
+                              "detail": {
+                                "type": "string",
+                                "example": "The requested resource cannot be found."
+                              },
+                              "source": {
+                                "oneOf": [
+                                  {
+                                    "type": "null"
+                                  },
+                                  {
+                                    "$ref": "#/components/schemas/Source"
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
+                "example": "\n{\n  \"errors\": [\n    {\n      \"status\": \"404\",\n      \"title\": \"Resource not found\",\n      \"detail\": \"The requested resource could not be found.\"\n    }\n  ]\n}\n"
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "required": [
+                        "errors"
+                      ],
+                      "properties": {
+                        "errors": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "status",
+                              "title",
+                              "detail"
+                            ],
+                            "properties": {
+                              "status": {
+                                "type": "string",
+                                "example": "404"
+                              },
+                              "title": {
+                                "type": "string",
+                                "example": "Not found"
+                              },
+                              "detail": {
+                                "type": "string",
+                                "example": "The requested resource cannot be found."
+                              },
+                              "source": {
+                                "oneOf": [
+                                  {
+                                    "type": "null"
+                                  },
+                                  {
+                                    "$ref": "#/components/schemas/Source"
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
+                "example": "\n{\n  \"errors\": [\n    {\n      \"status\": \"500\",\n      \"title\": \"Internal server error\",\n      \"detail\": \"The server has encountered a situation it does not know how to handle.\"\n    }\n  ]\n}\n"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ModelComponentType": {
+        "type": "integer",
+        "description": "The datatype of the model’s components.",
+        "enum": [
+          0,
+          1,
+          2,
+          3,
+          5,
+          6
+        ],
+        "example": 0
+      },
+      "ModelResourceCreationAttributes": {
+        "type": "object",
+        "required": [
+          "componentType",
+          "count",
+          "type"
+        ],
+        "properties": {
+          "byteOffset": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "An offset.",
+            "default": 0,
+            "minimum": 0
+          },
+          "componentType": {
+            "$ref": "#/components/schemas/ModelComponentType",
+            "description": "The datatype of the model’s components."
+          },
+          "count": {
+            "type": "integer",
+            "format": "int32",
+            "description": "A count.",
+            "minimum": 1
+          },
+          "type": {
+            "$ref": "#/components/schemas/ModelType",
+            "description": "Specifies the model’s type."
+          },
+          "array": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {},
+            "description": "An array."
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "A name."
+          }
+        }
+      },
+      "ModelResourceCreationPayload": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "default": "model"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "attributes"
+            ],
+            "properties": {
+              "attributes": {
+                "$ref": "#/components/schemas/ModelResourceCreationAttributes"
+              },
+              "relationships": {
+                "$ref": "#/components/schemas/ModelResourceCreationRelationships"
+              }
+            }
+          }
+        ]
+      },
+      "ModelResourceCreationRelationships": {
+        "type": "object",
+        "properties": {
+          "view": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ViewResourceRelationshipToOne"
+              }
+            ]
+          },
+          "subModel": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SubModelResourceRelationshipToOne"
+              }
+            ]
+          }
+        }
+      },
+      "ModelResourceCreationRequestBody": {
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ModelResourceCreationPayload"
+          }
+        }
+      },
+      "ModelResourceIdentifierObject": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "default": "model"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          }
+        ]
+      },
+      "ModelResourceObject": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ModelResourceIdentifierObject"
+          },
+          {
+            "type": "object",
+            "required": [
+              "attributes",
+              "relationships"
+            ],
+            "properties": {
+              "attributes": {
+                "$ref": "#/components/schemas/SubModelResourceAttributesObject"
+              },
+              "relationships": {
+                "$ref": "#/components/schemas/SubModelResourceRelationshipsObject"
+              }
+            }
+          }
+        ],
+        "description": "Some model included in the original model."
+      },
+      "ModelResourceRelationshipValue": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/SubModelResourceObject"
+          },
+          {
+            "$ref": "#/components/schemas/ViewResourceObject"
+          }
+        ]
+      },
+      "SubModelResourceAttributesObject": {
+        "type": "object",
+        "properties": {
+          "byteOffset": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "The offset.",
+            "default": 0,
+            "minimum": 0
+          },
+          "componentType": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ModelComponentType",
+                "description": "The datatype of the model."
+              }
+            ]
+          },
+          "count": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "A number.",
+            "minimum": 1
+          },
+          "type": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ModelType",
+                "description": "The model’s type."
+              }
+            ]
+          },
+          "array": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {},
+            "description": "An array."
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "A name."
+          }
+        }
+      },
+      "SubModelResourceRelationshipsObject": {
+        "type": "object",
+        "properties": {
+          "view": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ViewResourceRelationshipToOne"
+              }
+            ]
+          },
+          "subModel": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SubModelResourceRelationshipToOne"
+              }
+            ]
+          }
+        }
+      },
+      "SubModelResourceIdentifierObject": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "default": "model-subModel"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          }
+        ]
+      },
+      "SubModelResourceObject": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SubModelResourceIdentifierObject"
+          },
+          {
+            "type": "object",
+            "required": [
+              "attributes",
+              "relationships"
+            ],
+            "properties": {
+              "attributes": {
+                "$ref": "#/components/schemas/SubSubModelResourceAttributesObject"
+              },
+              "relationships": {
+                "$ref": "#/components/schemas/SubSubModelResourceRelationshipsObject"
+              }
+            }
+          }
+        ],
+        "description": "Some submodel."
+      },
+      "SubModelResourceRelationshipToOne": {
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/SubModelResourceIdentifierObject"
+          }
+        }
+      },
+      "SubSubModelResourceAttributesObject": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "A number.",
+            "minimum": 0
+          }
+        }
+      },
+      "SubSubModelResourceRelationshipsObject": {
+        "type": "object",
+        "properties": {
+          "values": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SubModelValuesResourceRelationshipToOne"
+              }
+            ]
+          }
+        }
+      },
+      "SubModelValuesResourceIdentifierObject": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "default": "model-sub-model-values"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          }
+        ]
+      },
+      "SubModelValuesResourceRelationshipToOne": {
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/SubModelValuesResourceIdentifierObject"
+          }
+        }
+      },
+      "ModelType": {
+        "type": "string",
+        "description": "Set a model type",
+        "enum": [
+          "TYPE_A",
+          "TYPE_B",
+          "TYPE_C"
+        ]
+      },
+      "ViewResourceIdentifierObject": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "default": "view"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          }
+        ]
+      },
+      "ViewResourceObject": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ViewResourceIdentifierObject"
+          }
+        ],
+        "description": "A view."
+      },
+      "ViewResourceRelationshipToOne": {
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ViewResourceIdentifierObject"
+          }
+        }
+      },
+      "Source": {
+        "type": "object",
+        "required": [
+          "pointer"
+        ],
+        "properties": {
+          "pointer": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Model",
+      "description": "Endpoints for the `Model` resource."
+    }
+  ]
+}


### PR DESCRIPTION
## Issues still present in our case:

### Field missing in MeshPrimitive.relationships

`targets` is empty in the creation of the primitive (also null in update but expected).

Fixed in: https://github.com/lx-industries/n8n-openapi-node/pull/1/commits/682bc1ec30f06fb957a30e3f5e6b0a89201e8359

### Default value incorrect

- In MeshPrimitive.attributes.mode in the update ONLY, the value is null instead of 4.
- KHR lights, the type is null  or `directional` instead of `point`

Fixed in: https://github.com/lx-industries/n8n-openapi-node/pull/1/commits/f7af0fd5ffde95dd89245f2fbc2252706304a351

### The value of the number is 0 most of the time

Fixed in: https://github.com/lx-industries/n8n-openapi-node/pull/1/commits/170399e3451171641bcf446c408331bd3311fa71

### Imports for buffets and GlTF

Not implemented in n8n I believe according to the documentation: https://docs.n8n.io/integrations/creating-nodes/build/reference/ui-elements/