### PR TITLE
Fix multiOptions detection when array items is a $ref to an enum

### DIFF
--- a/src/n8n/SchemaToINodeProperties.ts
+++ b/src/n8n/SchemaToINodeProperties.ts
@@ -65,9 +65,11 @@ export class N8NINodeProperties {
                 break;
             case 'array':
                 let schemaAsArray = schema as any;
-                if (schemaAsArray.items && schemaAsArray.items.enum && schemaAsArray.items.enum.length > 0) {
+                // items may be a $ref (e.g. to an enum schema) - resolve it before inspecting
+                const items = schemaAsArray.items ? this.refResolver.resolve<any>(schemaAsArray.items) : undefined;
+                if (items && items.enum && items.enum.length > 0) {
                     type = 'multiOptions';
-                    options = schemaAsArray.items.enum.map((value: string) => {
+                    options = items.enum.map((value: string) => {
                         return {
                             name: lodash.startCase(value),
                             value: value,
@@ -134,7 +136,7 @@ export class N8NINodeProperties {
                     send: {
                         type: 'query',
                         property: parameter.name,
-                        value: fieldSchemaKeys.type === "multiOptions" && !parameter.explode ? "={{ $value.join(',') }}" : '={{ $value }}',
+                        value: fieldSchemaKeys.type === "multiOptions" && !parameter.explode ? "={{ Array.isArray($value) ? $value.join(',') : $value }}" : '={{ $value }}',
                         propertyInDotNotation: false,
                     },
                 };

--- a/tests/jsonapi-openapi.spec.ts
+++ b/tests/jsonapi-openapi.spec.ts
@@ -118,7 +118,7 @@ test('petstore.json', () => {
                 "send": {
                     "type": "query",
                     "property": "fields[model]",
-                    "value": "={{ $value.join(',') }}",
+                    "value": "={{ Array.isArray($value) ? $value.join(',') : $value }}",
                     "propertyInDotNotation": false
                 }
             },
@@ -155,7 +155,43 @@ test('petstore.json', () => {
                 "send": {
                     "type": "query",
                     "property": "include",
-                    "value": "={{ $value.join(',') }}",
+                    "value": "={{ Array.isArray($value) ? $value.join(',') : $value }}",
+                    "propertyInDotNotation": false
+                }
+            },
+            "displayOptions": {
+                "show": {
+                    "resource": [
+                        "Model"
+                    ],
+                    "operation": [
+                        "Create Model"
+                    ]
+                }
+            }
+        },
+        {
+            "displayName": "Sort",
+            "name": "sort",
+            "default": [
+                "id"
+            ],
+            "type": "multiOptions",
+            "options": [
+                {
+                    "name": "Id",
+                    "value": "id"
+                },
+                {
+                    "name": "Name",
+                    "value": "name"
+                }
+            ],
+            "routing": {
+                "send": {
+                    "type": "query",
+                    "property": "sort",
+                    "value": "={{ Array.isArray($value) ? $value.join(',') : $value }}",
                     "propertyInDotNotation": false
                 }
             },

--- a/tests/samples/jsonapi-openapi.json
+++ b/tests/samples/jsonapi-openapi.json
@@ -53,6 +53,17 @@
               }
             },
             "explode": false
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ModelSortField"
+              }
+            },
+            "explode": false
           }
         ],
         "requestBody": {
@@ -253,7 +264,7 @@
     "schemas": {
       "ModelComponentType": {
         "type": "integer",
-        "description": "The datatype of the model’s components.",
+        "description": "The datatype of the model\u2019s components.",
         "enum": [
           0,
           1,
@@ -284,7 +295,7 @@
           },
           "componentType": {
             "$ref": "#/components/schemas/ModelComponentType",
-            "description": "The datatype of the model’s components."
+            "description": "The datatype of the model\u2019s components."
           },
           "count": {
             "type": "integer",
@@ -294,7 +305,7 @@
           },
           "type": {
             "$ref": "#/components/schemas/ModelType",
-            "description": "Specifies the model’s type."
+            "description": "Specifies the model\u2019s type."
           },
           "array": {
             "type": [
@@ -480,7 +491,7 @@
               },
               {
                 "$ref": "#/components/schemas/ModelType",
-                "description": "The model’s type."
+                "description": "The model\u2019s type."
               }
             ]
           },
@@ -722,6 +733,13 @@
             "type": "string"
           }
         }
+      },
+      "ModelSortField": {
+        "type": "string",
+        "enum": [
+          "id",
+          "name"
+        ]
       }
     }
   },


### PR DESCRIPTION
## Problem

For an array-typed query parameter whose `items` is a `$ref` to an enum schema, `N8NINodeProperties.fromSchema` checks `items.enum` on the **unresolved** `$ref` object. The check fails, so the parameter falls into the `json` branch: the field gets `JSON.stringify(<example>, null, 2)` as its default, and that string is sent verbatim in the query.

Found while testing the generated glTF Live node against `gltf-live v0.102.0` ([context](https://git.aerys.in/lx-industries/gltf-live/-/merge_requests/874#note_748738)): the new `sort` parameter on `GET /api/gltf/{gltf_id}/nodes` (`items: {$ref: NodeResourceQuerySortField}`, `explode: false`) is emitted as `sort=[\n  "id"\n]`, which the API rejects with `400 Invalid sort parameter`.

## Fix

- Resolve `items` through the `RefResolver` before the enum check, so `$ref`'d enums produce a proper `multiOptions` field (the CSV serialization for `explode: false` already exists).
- Guard the CSV routing expression with `Array.isArray($value)`: existing workflows may pin these fields to a plain string (e.g. `""`), which would otherwise crash on `.join()` now that the field type changes to `multiOptions`.

## Test

Added a `sort` parameter with `$ref`'d enum items to the JSON:API sample and its expected `multiOptions` property — it reproduces the bug (fails on `main`, passes with the fix). Full suite: 20/20.
